### PR TITLE
Torrent names improvements in ilcorsaronero.py

### DIFF
--- a/src/engines/ilcorsaronero.py
+++ b/src/engines/ilcorsaronero.py
@@ -69,10 +69,14 @@ class ilcorsaronero(object):
                     r'A class=\"tab\" HREF=\"(.+?)\" >(.+?)?</A>.+?([0-9\.\,]+ (TB|GB|MB|KB)).+?value=\"(.+?)\".+?#[0-9a-zA-Z]{6}\'>([0-9,]+)<.+?#[0-9a-zA-Z]{6}\'>([0-9,]+)',
                     tr)
                 if url_titles:
-                    name = url_titles.group(1).split("/")[5]
+                    name = url_titles.group(1).split("/")[5].replace("_", " ")
+                    try:
+                        name = url_titles.group(2)[:55] + " ".join(name[55:].split())
+                    except TypeError:
+                        name = " ".join(name.split())
                     torrents.append([
                         'https://itorrents.org/torrent/{0}.torrent'.format(url_titles.group(5)),
-                        name.replace("_", " "),
+                        name,
                         url_titles.group(3).replace(",", ""),
                         url_titles.group(6).replace(",", ""),
                         url_titles.group(7).replace(",", ""),

--- a/src/engines/ilcorsaronero.py
+++ b/src/engines/ilcorsaronero.py
@@ -71,7 +71,9 @@ class ilcorsaronero(object):
                 if url_titles:
                     name = url_titles.group(1).split("/")[5].replace("_", " ")
                     try:
-                        name = url_titles.group(2)[:55] + " ".join(name[55:].split())
+                        name_start = url_titles.group(2)[:55]
+                        divider = " " if " " in name_start else "."
+                        name = name_start + divider.join(name[55:].split())
                     except TypeError:
                         name = " ".join(name.split())
                     torrents.append([


### PR DESCRIPTION
I removed multiple whitespace characters in torrent names using `" ".join(name.split())`.

`url_titles.group(2)[:55]` allows to use the original name (the site cuts the name after the 55th character putting `..` after that), in order to keep special characters, instead of getting the entire name from the description link. The exception is mandatory because the original name is empty sometimes, then `url_titles.group(2) = None`.

The variable words divider (`" "` or `"."`) is just a finesse.